### PR TITLE
Allow annotation of `resource` properties in named individuals for logging

### DIFF
--- a/cram_beliefstate/src/beliefstate.lisp
+++ b/cram_beliefstate/src/beliefstate.lisp
@@ -248,11 +248,12 @@
   (alter-node (list (list :command :rethrow-failure)
                     (list :context-id id))))
 
-(defun set-experiment-meta-data (field value)
+(defun set-experiment-meta-data (field value &optional (type "property"))
   (alter-node
    `((:command :set-experiment-meta-data)
      (:field ,field)
-     (:value ,value))))
+     (:value ,value)
+     (:type ,type))))
 
 (defun add-topic-image-to-active-node (image-topic)
   (alter-node


### PR DESCRIPTION
This is the interface side of what is going to be a new feature in the semrec logger. It doesn't matter whether the logger is not yet updated upstream, as the field is ignored in the current version. So if it compiles, it should be fine even without the other side.