### PR TITLE
Resource annotations

### DIFF
--- a/cram_beliefstate/src/beliefstate.lisp
+++ b/cram_beliefstate/src/beliefstate.lisp
@@ -248,12 +248,15 @@
   (alter-node (list (list :command :rethrow-failure)
                     (list :context-id id))))
 
-(defun set-experiment-meta-data (field value &optional (type "property"))
+(defun set-experiment-meta-data (field value &optional (type :property))
+  (assert (or (eql type :property) (eql type :resource)))
   (alter-node
    `((:command :set-experiment-meta-data)
      (:field ,field)
      (:value ,value)
-     (:type ,type))))
+     (:type ,(case type
+               (:property "property")
+               (:resource "resource"))))))
 
 (defun add-topic-image-to-active-node (image-topic)
   (alter-node
@@ -379,7 +382,7 @@
              sem-map-utils::*cached-semantic-map-name*)
     (set-experiment-meta-data
      "performedInMap" sem-map-utils::*cached-semantic-map-name*
-     "resource")))
+     :resource)))
 
 (defun extract-files (&key (name "cram_log") detail-level)
   (set-semantic-map-name)

--- a/cram_beliefstate/src/beliefstate.lisp
+++ b/cram_beliefstate/src/beliefstate.lisp
@@ -374,7 +374,15 @@
        (:type-parent ,type-parent)
        (:description-parent ,desc-parent)))))
 
+(defun set-semantic-map-name ()
+  (when (and (find-package 'sem-map-utils)
+             sem-map-utils::*cached-semantic-map-name*)
+    (set-experiment-meta-data
+     "performedInMap" sem-map-utils::*cached-semantic-map-name*
+     "resource")))
+
 (defun extract-files (&key (name "cram_log") detail-level)
+  (set-semantic-map-name)
   (extract-meta-file)
   (unless detail-level
     (let ((owl-name (concatenate 'string name ".owl"))


### PR DESCRIPTION
Use a fixed set of symbols rather than strings to identify the type of an annotation; also, automatically annotate the currently loaded (cached) semantic map name as `performedInMap` in the meta data individual (if `sem-map-utils` is present, that is).