### PR TITLE
Fix sem map utils dependency

### DIFF
--- a/cram_beliefstate/cram-beliefstate.asd
+++ b/cram_beliefstate/cram-beliefstate.asd
@@ -36,7 +36,6 @@
                cram-designators
                cram-language
                cram-tf
-               cram-semantic-map-utils
                cl-transforms
                cl-transforms-stamped
                cram-plan-failures

--- a/cram_beliefstate/package.xml
+++ b/cram_beliefstate/package.xml
@@ -27,7 +27,6 @@
   <build_depend>cram_designators</build_depend>
   <build_depend>cram_utilities</build_depend>
   <build_depend>cram_plan_failures</build_depend>
-  <build_depend>cram_semantic_map_utils</build_depend>
   <build_depend>cl_transforms</build_depend>
   <build_depend>cl_transforms_stamped</build_depend>
   <build_depend>cram_tf</build_depend>
@@ -43,7 +42,6 @@
   <run_depend>cram_designators</run_depend>
   <run_depend>cram_utilities</run_depend>
   <run_depend>cram_plan_failures</run_depend>
-  <run_depend>cram_semantic_map_utils</run_depend>
   <run_depend>cl_transforms</run_depend>
   <run_depend>cl_transforms_stamped</run_depend>
   <run_depend>cram_tf</run_depend>

--- a/cram_beliefstate/src/beliefstate.lisp
+++ b/cram_beliefstate/src/beliefstate.lisp
@@ -377,12 +377,19 @@
        (:type-parent ,type-parent)
        (:description-parent ,desc-parent)))))
 
+(defun get-package-symbol-value (package search-name)
+  (let ((package (find-package package))
+        (search-name (string-upcase search-name)))
+    (do-symbols (sym package)
+      (when (and (boundp sym) (equal (symbol-name sym) search-name))
+        (return-from get-package-symbol-value
+          (symbol-value sym))))))
+
 (defun set-semantic-map-name ()
-  (when (and (find-package 'sem-map-utils)
-             sem-map-utils::*cached-semantic-map-name*)
-    (set-experiment-meta-data
-     "performedInMap" sem-map-utils::*cached-semantic-map-name*
-     :resource)))
+  (let ((name (get-package-symbol-value
+               'sem-map-utils "*cached-semantic-map-name*")))
+    (when name
+      (set-experiment-meta-data "performedInMap" name :resource))))
 
 (defun extract-files (&key (name "cram_log") detail-level)
   (set-semantic-map-name)


### PR DESCRIPTION
Hey @gheorghelisca, thanks for the fix in https://github.com/cram2/cram_beliefstate/pull/4. I saw all of this too late and didn't see my brain fart from before (as documented in your original pull request [here](https://github.com/cram2/cram_beliefstate/pull/5#issuecomment-238366405)).

So the idea was to keep the dependency towards `cram_semantic_map_utils` out of `cram_beliefstate`; sorry I failed to do so with that other change.

I found a way to read the symbol's value anyway while first checking whether the package is present. This PR works for me and should do the trick, while removing again the dependency on sem-map-utils. Sorry for retracting your change with that.