### PR TITLE
Tracking the active node ID

### DIFF
--- a/cram_beliefstate/src/hooks.lisp
+++ b/cram_beliefstate/src/hooks.lisp
@@ -170,8 +170,7 @@
   (beliefstate:stop-node id))
 
 (def-logging-hook cram-language::on-with-designator (designator)
-  (beliefstate:add-designator-to-active-node
-   designator))
+  (beliefstate:add-designator-to-node designator (top-id)))
 
 (def-logging-hook cram-language::on-preparing-named-top-level (name)
   (let ((name (or name "ANONYMOUS-TOP-LEVEL")))


### PR DESCRIPTION
Tracking the active node ID allows easier (and less error prone) use of functions referring to the *active* node rather than specifying an ID explicitly.