### PR TITLE
Updating dependencies for cram4

### DIFF
--- a/cram_beliefstate/cram-beliefstate.asd
+++ b/cram_beliefstate/cram-beliefstate.asd
@@ -38,7 +38,7 @@
                cram-tf
                cl-transforms
                cl-transforms-stamped
-               cram-plan-failures
+               cram-common-failures
                roslisp
 
                ;; Communication

--- a/cram_beliefstate/package.xml
+++ b/cram_beliefstate/package.xml
@@ -26,7 +26,7 @@
   <build_depend>cram_language</build_depend>
   <build_depend>cram_designators</build_depend>
   <build_depend>cram_utilities</build_depend>
-  <build_depend>cram_plan_failures</build_depend>
+  <build_depend>cram_common_failures</build_depend>
   <build_depend>cl_transforms</build_depend>
   <build_depend>cl_transforms_stamped</build_depend>
   <build_depend>cram_tf</build_depend>
@@ -41,7 +41,7 @@
   <run_depend>cram_language</run_depend>
   <run_depend>cram_designators</run_depend>
   <run_depend>cram_utilities</run_depend>
-  <run_depend>cram_plan_failures</run_depend>
+  <run_depend>cram_common_failures</run_depend>
   <run_depend>cl_transforms</run_depend>
   <run_depend>cl_transforms_stamped</run_depend>
   <run_depend>cram_tf</run_depend>

--- a/cram_beliefstate/src/hooks.lisp
+++ b/cram_beliefstate/src/hooks.lisp
@@ -99,7 +99,7 @@
                                                (setf (gethash
                                                       (intern
                                                        (symbol-name fail)
-                                                       'cram-plan-failures)
+                                                       'cram-common-failures)
                                                       fail-hash)
                                                      val)))
                                     fail-hash))

--- a/cram_beliefstate/src/predict.lisp
+++ b/cram_beliefstate/src/predict.lisp
@@ -53,7 +53,7 @@
              (mapcar (lambda (failure-returned)
                        `(,(intern (symbol-name
                                    (car failure-returned))
-                                  'cram-plan-failures)
+                                  'cram-common-failures)
                          ,(cdr failure-returned)))
                      failures-returned))
             (t nil)))))


### PR DESCRIPTION
Removed deps to obsolete pkg cram-plan-failures.